### PR TITLE
fix: update workflow to run on main

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -2,7 +2,7 @@ name: Deploy to Firebase Functions on merge
 "on":
   push:
     branches:
-      - master
+      - main
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Turns out workflow never run because we still referenced main after switching repo